### PR TITLE
docs: note that an absent systemrealm.cfg intentionally hangs startup

### DIFF
--- a/docs/PRODUCTION-DEPLOYMENT.md
+++ b/docs/PRODUCTION-DEPLOYMENT.md
@@ -692,6 +692,14 @@ openssl x509 -in /opt/goss/ssl/goss-server.crt -text -noout
 openssl s_client -connect localhost:61443
 ```
 
+#### 5. Platform Startup Hangs with No Broker
+
+If the platform hangs at startup with no error message and the broker does not initialize, the system realm configuration may be missing. Starting with PR #1882, the system-authenticating Shiro realm (SystemBasedRealm) is a mandatory Declarative Services dependency for platform startup, declared with ConfigurationPolicy.REQUIRE and configuration PID pnnl.goss.core.security.systemrealm.
+
+When the configuration file pnnl.goss.core.security.systemrealm.cfg is absent, the system realm never publishes as a service. The mandatory @Reference that gates the broker and SecurityManager never binds, causing the platform startup to hang indefinitely with no broker started. This is intentional fail-closed behavior: the system will not start an insecure broker.
+
+Remedy: ensure the configuration file pnnl.goss.core.security.systemrealm.cfg is present and properly mounted in the deployment environment. If the file is missing, copy it from the distribution bundle or recreate it with appropriate security settings for your deployment.
+
 ### Getting Support
 
 1. **Check logs**: `/opt/goss/logs/`


### PR DESCRIPTION
## What
Adds a production-deployment troubleshooting note: after the system-realm activation-order fix (#1882), `SystemBasedRealm` is a mandatory Declarative Services dependency declared with `ConfigurationPolicy.REQUIRE`. When `pnnl.goss.core.security.systemrealm.cfg` is absent, the realm never publishes, the mandatory reference never binds, and startup hangs with no broker.

## Why
This is intentional fail-closed behavior (no insecure broker starts), but it presents as a silent hang with no obvious error. The note lets operators read the hang as a missing-config signal rather than a platform bug, with the remedy (ensure the cfg is present and mounted).

## Related
Follows the #1882 fix. Tracking #40.
