### PR TITLE
fix: resolve SSL runner export deps (pax-logging-log4j2, drop stale shiro pin)

### DIFF
--- a/cnf/ext/central.maven
+++ b/cnf/ext/central.maven
@@ -26,7 +26,7 @@ org.apache.felix:org.apache.felix.fileinstall:3.7.4
 
 # Pax Logging - OSGi logging framework
 org.ops4j.pax.logging:pax-logging-api:2.2.7
-org.ops4j.pax.logging:pax-logging-service:2.2.7
+org.ops4j.pax.logging:pax-logging-log4j2:2.2.7
 
 # H2 Database
 com.h2database:h2:2.3.232

--- a/cnf/ext/libraries.bnd
+++ b/cnf/ext/libraries.bnd
@@ -269,9 +269,9 @@ scr-runpath: ${scr};version=file,\
 
 # Pax Logging (OSGi logging framework)
 pax-logging-api: ${repo;org.ops4j.pax.logging:pax-logging-api;[2.2.0,3);HIGHEST}
-pax-logging-service: ${repo;org.ops4j.pax.logging:pax-logging-service;[2.2.0,3);HIGHEST}
+pax-logging-log4j2: ${repo;org.ops4j.pax.logging:pax-logging-log4j2;[2.2.0,3);HIGHEST}
 pax-logging-runpath: ${pax-logging-api};version=file,\
-  ${pax-logging-service};version=file
+  ${pax-logging-log4j2};version=file
 
 # Felix HTTP Service
 http-servlet-api: ${repo;org.apache.felix:org.apache.felix.http.servlet-api;[3.0.0,4);HIGHEST}

--- a/pnnl.goss.core.runner/goss-core-ssl.bndrun
+++ b/pnnl.goss.core.runner/goss-core-ssl.bndrun
@@ -20,7 +20,6 @@
 	${commons-io-runpath},\
 	${xstream-runpath},\
 	${gson-runpath},\
-	org.apache.shiro:shiro-core;version='[1.13.0,2)',\
 	javax.annotation:javax.annotation-api;version='[1.3.2,2)',\
 	pnnl.goss.core.core-api;version=latest,\
 	pnnl.goss.core.goss-client;version=latest,\

--- a/pnnl.goss.core.runner/goss-core.shared.bndrun
+++ b/pnnl.goss.core.runner/goss-core.shared.bndrun
@@ -33,7 +33,7 @@ shared.runrequires: \
 	osgi.identity;filter:='(osgi.identity=pnnl.goss.core.runner)',\
 	osgi.identity;filter:='(&(osgi.identity=org.apache.felix.scr)(version>=2.2.10))',\
 	osgi.identity;filter:='(osgi.identity=org.ops4j.pax.logging.pax-logging-api)',\
-	osgi.identity;filter:='(osgi.identity=org.ops4j.pax.logging.pax-logging-service)',\
+	osgi.identity;filter:='(osgi.identity=org.ops4j.pax.logging.pax-logging-log4j2)',\
 	osgi.identity;filter:='(&(osgi.identity=org.apache.felix.gogo.runtime)(version>=1.1.6))',\
 	osgi.identity;filter:='(&(osgi.identity=org.apache.felix.gogo.shell)(version>=1.1.4))',\
 	osgi.identity;filter:='(&(osgi.identity=org.apache.felix.gogo.command)(version>=1.1.2))',\


### PR DESCRIPTION
## Problem
The release workflow's build-artifacts step failed at `export.goss-core-ssl` (layer 2 of the standing release breakage; layer 1 was the stale launcher jar, PR #48). The SSL runner bndrun required two dependencies unresolvable on a clean runner:
- `pax-logging-service:2.2.7` does not exist on Maven Central (HTTP 404). The pax-logging 2.x line renamed the backend bundle; the correct artifact is `pax-logging-log4j2:2.2.7`.
- `shiro-core;version='[1.13.0,2)'` was hardcoded but self-conflicting: the same bndrun already pulls shiro-core 2.0.0 via `activemq-runpath` (required by activemq-shiro 6.2.0), and the range excludes 2.0.0.

## Fix (4 files, 5 lines net)
- `central.maven`: `pax-logging-service:2.2.7` to `pax-logging-log4j2:2.2.7`.
- `libraries.bnd`: rename the macro and update the runpath.
- `goss-core.shared.bndrun`: update the `-runrequires` osgi.identity filter to the new BSN `org.ops4j.pax.logging.pax-logging-log4j2`.
- `goss-core-ssl.bndrun`: delete the redundant, conflicting shiro-core line.

## Backend note
`pax-logging-log4j2` is the correct name for the pax-logging 2.x backend, not a cosmetic rename: it is a genuine Log4j 2.x backend continuation of the legacy 1.x `service` aggregator (which never published a 2.x artifact). A follow-up tracks verifying the runner's Log4j-1.x-format logging config is still honored at runtime, or migrating it.

## Verification
Both `export.goss-core` and `export.goss-core-ssl` build green locally, producing `goss-core.jar` and `goss-core-ssl.jar` (the SSL jar embeds `pax-logging-log4j2-2.2.7` and `shiro-core-2.0.0`). The full `assemble export` is green, and the downstream changelog and archive steps run on real content. Artifact existence independently verified against Maven Central. Reviewed and approved (Dutch): BSN confirmed by manifest inspection, no stragglers, shiro deletion safe.
